### PR TITLE
fix(pie) fixed half pie slices propotions

### DIFF
--- a/src/chart/pie/pieLayout.ts
+++ b/src/chart/pie/pieLayout.ts
@@ -26,6 +26,7 @@ import PieSeriesModel from './PieSeries';
 import { SectorShape } from 'zrender/src/graphic/shape/Sector';
 import { normalizeArcAngles } from 'zrender/src/core/PathProxy';
 import { makeInner } from '../../util/model';
+import { checkPieIsHalf } from './utils/checkPieIsHalf';
 
 const PI2 = Math.PI * 2;
 const RADIAN = Math.PI / 180;
@@ -33,9 +34,9 @@ const RADIAN = Math.PI / 180;
 function getViewRect(seriesModel: PieSeriesModel, api: ExtensionAPI) {
     return layout.getLayoutRect(
         seriesModel.getBoxLayoutParams(), {
-            width: api.getWidth(),
-            height: api.getHeight()
-        }
+        width: api.getWidth(),
+        height: api.getHeight()
+    }
     );
 }
 
@@ -108,7 +109,7 @@ export default function pieLayout(
             !isNaN(value) && validDataCount++;
         });
 
-        const sum = data.getSum(valueDim);
+        const sum = data.getSum(valueDim, checkPieIsHalf(data));
         // Sum may be 0
         let unitRadian = Math.PI / (sum || validDataCount) * 2;
 

--- a/src/chart/pie/utils/checkPieIsHalf.ts
+++ b/src/chart/pie/utils/checkPieIsHalf.ts
@@ -1,0 +1,30 @@
+import SeriesData, { DefaultDataVisual } from "../../../data/SeriesData";
+import PieSeriesModel from "../PieSeries";
+
+interface IPieSourceData {
+    emphasis?: {
+        label?: {
+            show?: boolean;
+        }
+    };
+    itemStyle: {
+        color: string;
+        opacity?: number;
+    };
+    label?: {
+        show: boolean;
+    };
+    name?: string;
+    value: number;
+}
+
+export function checkPieIsHalf(data: SeriesData<PieSeriesModel, DefaultDataVisual>): boolean {
+    const source = data?.getStore()?.getSource()?.data as Array<IPieSourceData>
+    if (!source?.length) return false;
+    const last = source[source.length - 1]
+
+    return !!(last?.itemStyle?.color === 'none'
+        && last?.itemStyle?.opacity === undefined
+        && last?.label?.show === false)
+
+}

--- a/src/data/DataStore.ts
+++ b/src/data/DataStore.ts
@@ -109,7 +109,7 @@ export interface DataStoreDimensionDefine {
     ordinalOffset?: number
 }
 
-let defaultDimValueGetters: {[sourceFormat: string]: DimValueGetter};
+let defaultDimValueGetters: { [sourceFormat: string]: DimValueGetter };
 
 function getIndicesCtor(rawCount: number): DataArrayLikeConstructor {
     // The possible max value in this._indicies is always this._rawCount despite of filtering.
@@ -204,7 +204,7 @@ class DataStore {
 
         const source = provider.getSource();
         const defaultGetter = this.defaultDimValueGetter =
-             defaultDimValueGetters[source.sourceFormat];
+            defaultDimValueGetters[source.sourceFormat];
         // Default dim value getter
         this._dimValueGetter = dimValueGetter || defaultGetter;
 
@@ -225,6 +225,8 @@ class DataStore {
         });
 
         this._initDataFromProvider(0, provider.count());
+
+
     }
 
     getProvider(): DataProvider {
@@ -368,7 +370,7 @@ class DataStore {
 
         this._rawCount = this._count = end;
 
-        return {start, end};
+        return { start, end };
     }
 
     private _initDataFromProvider(
@@ -483,16 +485,21 @@ class DataStore {
         return dimStore ? dimStore[rawIdx] : NaN;
     }
 
+
+
     /**
      * Get sum of data in one dimension
      */
-    getSum(dim: DimensionIndex): number {
+    getSum(dim: DimensionIndex, isHalfPie?: boolean): number {
         const dimData = this._chunks[dim];
         let sum = 0;
         if (dimData) {
             for (let i = 0, len = this.count(); i < len; i++) {
                 const value = this.get(dim, i) as number;
-                if (!isNaN(value)) {
+                if (i === len - 1 && isHalfPie) {
+                    sum *= 2;
+                }
+ else if (!isNaN(value)) {
                     sum += value;
                 }
             }
@@ -522,8 +529,8 @@ class DataStore {
         return len === 0
             ? 0
             : len % 2 === 1
-            ? sortedDimDataArray[(len - 1) / 2]
-            : (sortedDimDataArray[len / 2] + sortedDimDataArray[len / 2 - 1]) / 2;
+                ? sortedDimDataArray[(len - 1) / 2]
+                : (sortedDimDataArray[len / 2] + sortedDimDataArray[len / 2 - 1]) / 2;
     }
 
     /**
@@ -716,7 +723,7 @@ class DataStore {
      * Select data in range. (For optimization of filter)
      * (Manually inline code, support 5 million data filtering in data zoom.)
      */
-    selectRange(range: {[dimIdx: number]: [number, number]}): DataStore {
+    selectRange(range: { [dimIdx: number]: [number, number] }): DataStore {
         const newStore = this.clone();
 
         const len = newStore._count;
@@ -774,8 +781,8 @@ class DataStore {
                     const val2 = dimStorage2[i];
                     // Do not filter NaN, see comment above.
                     if ((
-                            (val >= min && val <= max) || isNaN(val as any)
-                        )
+                        (val >= min && val <= max) || isNaN(val as any)
+                    )
                         && (
                             (val2 >= min2 && val2 <= max2) || isNaN(val2 as any)
                         )

--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -21,13 +21,13 @@
 
 
 import * as zrUtil from 'zrender/src/core/util';
-import {PathStyleProps} from 'zrender/src/graphic/Path';
+import { PathStyleProps } from 'zrender/src/graphic/Path';
 import Model from '../model/Model';
 import DataDiffer from './DataDiffer';
-import {DataProvider, DefaultDataProvider} from './helper/dataProvider';
-import {summarizeDimensions, DimensionSummary} from './helper/dimensionHelper';
+import { DataProvider, DefaultDataProvider } from './helper/dataProvider';
+import { summarizeDimensions, DimensionSummary } from './helper/dimensionHelper';
 import SeriesDimensionDefine from './SeriesDimensionDefine';
-import {ArrayLike, Dictionary, FunctionPropertyNames} from 'zrender/src/core/types';
+import { ArrayLike, Dictionary, FunctionPropertyNames } from 'zrender/src/core/types';
 import Element from 'zrender/src/Element';
 import {
     DimensionIndex, DimensionName, DimensionLoose, OptionDataItem,
@@ -37,12 +37,12 @@ import {
     OrdinalNumber,
     OrdinalRawValue
 } from '../util/types';
-import {convertOptionIdName, isDataItemOption} from '../util/model';
+import { convertOptionIdName, isDataItemOption } from '../util/model';
 import { setCommonECData } from '../util/innerStore';
 import type Graph from './Graph';
 import type Tree from './Tree';
 import type { VisualMeta } from '../component/visualMap/VisualMapModel';
-import {isSourceInstance, Source} from './Source';
+import { isSourceInstance, Source } from './Source';
 import { LineStyleProps } from '../model/mixin/lineStyle';
 import DataStore, { DataStoreDimensionDefine, DimValueGetter } from './DataStore';
 import { isSeriesDataSchema, SeriesDataSchema } from './helper/SeriesDataSchema';
@@ -58,7 +58,7 @@ const ID_PREFIX = 'e\0\0';
 
 const INDEX_NOT_FOUND = -1;
 
-type NameRepeatCount = {[name: string]: number};
+type NameRepeatCount = { [name: string]: number };
 type ItrParamDims = DimensionLoose | Array<DimensionLoose>;
 // If Ctx not specified, use List as Ctx
 type CtxOrList<Ctx> = unknown extends Ctx ? SeriesData : Ctx;
@@ -294,10 +294,10 @@ class SeriesData<
 
             const dimensionInfo: SeriesDimensionDefine =
                 zrUtil.isString(dimInfoInput)
-                ? new SeriesDimensionDefine({name: dimInfoInput})
-                : !(dimInfoInput instanceof SeriesDimensionDefine)
-                ? new SeriesDimensionDefine(dimInfoInput)
-                : dimInfoInput;
+                    ? new SeriesDimensionDefine({ name: dimInfoInput })
+                    : !(dimInfoInput instanceof SeriesDimensionDefine)
+                        ? new SeriesDimensionDefine(dimInfoInput)
+                        : dimInfoInput;
 
             const dimensionName = dimensionInfo.name;
             dimensionInfo.type = dimensionInfo.type || 'float';
@@ -406,8 +406,8 @@ class SeriesData<
         return dimInfo
             ? dimInfo.storeDimIndex
             : this._dimOmitted
-            ? this._schema.getSourceDimensionIndex(dim as DimensionName)
-            : -1;
+                ? this._schema.getSourceDimensionIndex(dim as DimensionName)
+                : -1;
     }
 
     /**
@@ -583,7 +583,7 @@ class SeriesData<
      *        Each item is exactly corresponding to a dimension.
      */
     appendValues(values: any[][], names?: string[]): void {
-        const {start, end} = this._store.appendValues(values, names.length);
+        const { start, end } = this._store.appendValues(values, names.length);
         const shouldMakeIdFromName = this._shouldMakeIdFromName();
 
         this._updateOrdinalMeta();
@@ -795,8 +795,8 @@ class SeriesData<
         return this._store.getDataExtent(this._getStoreDimIndex(dim));
     }
 
-    getSum(dim: DimensionLoose): number {
-        return this._store.getSum(this._getStoreDimIndex(dim));
+    getSum(dim: DimensionLoose, isHalfPie?: boolean): number {
+        return this._store.getSum(this._getStoreDimIndex(dim), isHalfPie);
     }
 
     getMedian(dim: DimensionLoose): number {
@@ -1124,8 +1124,8 @@ class SeriesData<
      */
     // TODO: Type of data item
     getItemModel<ItemOpts extends unknown = unknown>(idx: number): Model<ItemOpts
-        // Extract item option with value key. FIXME will cause incompatible issue
-        // Extract<HostModel['option']['data'][number], { value?: any }>
+    // Extract item option with value key. FIXME will cause incompatible issue
+    // Extract<HostModel['option']['data'][number], { value?: any }>
     > {
         const hostModel = this.hostModel;
         const dataItem = this.getRawDataItem(idx) as ModelOption;


### PR DESCRIPTION
Kaiten: https://techaudit.kaiten.ru/space/127111/card/37593950

Описание проблемы: наша реализация половинного отображение работает путём добавления пустого элемента, размером со все имеющиеся данные. В функционале легенды при отключении отдельных элементов, оставшиеся растягиваются на освободившееся пространство, Но пустой элемент в этот момент по прежнему имеет значение в половину изначальных данных. 

Решение: Добавил программный рассчёт пустого элемента для общей суммы значений в кейса половинного чарта.




### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
